### PR TITLE
Implementa consulta com Specification para busca de eventos

### DIFF
--- a/.idea/modules.xml
+++ b/.idea/modules.xml
@@ -1,8 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<project version="4">
-  <component name="ProjectModuleManager">
-    <modules>
-      <module fileurl="file://$PROJECT_DIR$/backend/Orbis.iml" filepath="$PROJECT_DIR$/backend/Orbis.iml" />
-    </modules>
-  </component>
-</project>

--- a/backend/src/main/java/br/com/orbis/Orbis/controller/EventController.java
+++ b/backend/src/main/java/br/com/orbis/Orbis/controller/EventController.java
@@ -12,7 +12,9 @@ import org.slf4j.LoggerFactory;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
+import org.springframework.format.annotation.DateTimeFormat;
 
+import java.time.LocalDate;
 import java.io.IOException;
 import java.util.List;
 
@@ -70,6 +72,17 @@ public class EventController {
             @RequestParam(required = false) String category,
             @RequestParam(required = false) String tag) {
         return ResponseEntity.ok(service.searchByCategoryAndTag(category, tag));
+    }
+
+    @GetMapping("/search-dynamic")
+    public ResponseEntity<List<Event>> searchEventsWithFilters(
+            @RequestParam(required = false) String title,
+            @RequestParam(required = false) String location,
+            @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate startDate,
+            @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate endDate) {
+
+        List<Event> events = service.searchEventsWithFilters(title, location, startDate, endDate);
+        return ResponseEntity.ok(events);
     }
 
     @PutMapping(value = "/{eventId}", consumes = {"multipart/form-data", "application/json"})

--- a/backend/src/main/java/br/com/orbis/Orbis/repository/EventRepository.java
+++ b/backend/src/main/java/br/com/orbis/Orbis/repository/EventRepository.java
@@ -2,13 +2,14 @@ package br.com.orbis.Orbis.repository;
 
 import br.com.orbis.Orbis.model.Event;
 import org.springframework.data.jpa.repository.*;
+import org.springframework.data.jpa.domain.Specification;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
 
 @Repository
-public interface EventRepository extends JpaRepository<Event, Long> {
+public interface EventRepository extends JpaRepository<Event, Long>, JpaSpecificationExecutor<Event> {
 
     List<Event> findByOrganizerId(Long organizerId);
 

--- a/backend/src/main/java/br/com/orbis/Orbis/service/EventService.java
+++ b/backend/src/main/java/br/com/orbis/Orbis/service/EventService.java
@@ -8,7 +8,9 @@ import br.com.orbis.Orbis.repository.EventRepository;
 import br.com.orbis.Orbis.repository.UserRepository;
 import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
+import org.springframework.data.jpa.domain.Specification;
 
+import java.time.LocalDate;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Paths;
@@ -67,6 +69,15 @@ public class EventService {
         return repository.findByCategoryAndTag(category, tag);
     }
 
+    public List<Event> searchEventsWithFilters(String title, String location, LocalDate startDate, LocalDate endDate) {
+        Specification<Event> spec = Specification
+                .where(EventSpecifications.hasTitle(title))
+                .and(EventSpecifications.hasLocation(location))
+                .and(EventSpecifications.isAfterDate(startDate))
+                .and(EventSpecifications.isBeforeDate(endDate));
+
+        return repository.findAll(spec);
+    }
 
     public Event updateEvent(Long eventId, EventDTO eventDto, MultipartFile image, Long currentOrganizerId) throws IOException {
         Optional<Event> existingEvent = repository.findById(eventId);

--- a/backend/src/main/java/br/com/orbis/Orbis/service/EventSpecifications.java
+++ b/backend/src/main/java/br/com/orbis/Orbis/service/EventSpecifications.java
@@ -1,0 +1,57 @@
+package br.com.orbis.Orbis.service;
+
+import br.com.orbis.Orbis.model.Event;
+import org.springframework.data.jpa.domain.Specification;
+
+import java.time.LocalDate;
+
+public class EventSpecifications {
+
+    // Specification para buscar por título
+    public static Specification<Event> hasTitle(String title) {
+        return (root, query, criteriaBuilder) -> {
+            // Se title for null, retorna null (não aplica filtro)
+            if (title == null || title.trim().isEmpty()) {
+                return null;
+            }
+            // Cria um LIKE case-insensitive
+            return criteriaBuilder.like(
+                    criteriaBuilder.lower(root.get("title")),
+                    "%" + title.toLowerCase() + "%"
+            );
+        };
+    }
+
+    // Specification para buscar por localização
+    public static Specification<Event> hasLocation(String location) {
+        return (root, query, criteriaBuilder) -> {
+            if (location == null || location.trim().isEmpty()) {
+                return null;
+            }
+            return criteriaBuilder.like(
+                    criteriaBuilder.lower(root.get("location")),
+                    "%" + location.toLowerCase() + "%"
+            );
+        };
+    }
+
+    // Specification para buscar eventos após uma data
+    public static Specification<Event> isAfterDate(LocalDate date) {
+        return (root, query, criteriaBuilder) -> {
+            if (date == null) {
+                return null;
+            }
+            return criteriaBuilder.greaterThanOrEqualTo(root.get("date"), date);
+        };
+    }
+
+    // Specification para buscar eventos antes de uma data
+    public static Specification<Event> isBeforeDate(LocalDate date) {
+        return (root, query, criteriaBuilder) -> {
+            if (date == null) {
+                return null;
+            }
+            return criteriaBuilder.lessThanOrEqualTo(root.get("date"), date);
+        };
+    }
+}


### PR DESCRIPTION
Este PR implementa a busca dinâmica de eventos utilizando a interface Specification do Spring Data JPA.

O que foi feito:
- A interface EventRepository agora estende JpaSpecificationExecutor.
- Foi criada a classe EventSpecifications para conter a lógica dos filtros (título, localização, data).
- O EventService foi atualizado com um novo método searchEventsWithFilters.
- Um novo endpoint GET /events/search-dynamic foi adicionado no EventController.

Como testar:
É possível testar a nova funcionalidade com requisições como:
GET /events/search-dynamic?title=tech&location=online
GET /events/search-dynamic?startDate=2025-10-01